### PR TITLE
Allow applications on lockscreen

### DIFF
--- a/res/layout/app_settings.xml
+++ b/res/layout/app_settings.xml
@@ -128,6 +128,11 @@
                     android:layout_height="wrap_content"
                     android:text="Screen on" />
             </LinearLayout>
+            <CheckBox
+                android:id="@+id/chkAllowOnLockscreen"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Show when phone locked" />    
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/res/layout/filter_dialog.xml
+++ b/res/layout/filter_dialog.xml
@@ -62,6 +62,11 @@
                 android:layout_height="wrap_content"
                 app:label="No title" />
             <de.robv.android.xposed.mods.appsettings.FilterItemComponent
+                android:id="@+id/fltAllowOnLockscreen"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:label="Allowed on lockscreen" />
+            <de.robv.android.xposed.mods.appsettings.FilterItemComponent
                 android:id="@+id/fltScreenOn"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/src/de/robv/android/xposed/mods/appsettings/Common.java
+++ b/src/de/robv/android/xposed/mods/appsettings/Common.java
@@ -28,6 +28,7 @@ public class Common {
 	public static final String PREF_REVOKELIST = "/revoke-list";
 	public static final String PREF_FULLSCREEN = "/fullscreen";
 	public static final String PREF_NO_TITLE = "/no-title";
+	public static final String PREF_ALLOW_ON_LOCKSCREEN = "/allow-on-lockscreen";
 	public static final String PREF_SCREEN_ON = "/screen-on";
 	public static final String PREF_ORIENTATION = "/orientation";
 

--- a/src/de/robv/android/xposed/mods/appsettings/XposedModActivity.java
+++ b/src/de/robv/android/xposed/mods/appsettings/XposedModActivity.java
@@ -55,6 +55,7 @@ public class XposedModActivity extends Activity {
 	private FilterState filterLocale;
 	private FilterState filterFullscreen;
 	private FilterState filterNoTitle;
+	private FilterState filterAllowOnLockscreen;
 	private FilterState filterScreenOn;
 	private FilterState filterOrientation;
 	private FilterState filterResident;
@@ -206,6 +207,7 @@ public class XposedModActivity extends Activity {
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltLocale)).setFilterState(filterLocale);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltFullscreen)).setFilterState(filterFullscreen);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltNoTitle)).setFilterState(filterNoTitle);
+				((FilterItemComponent) filterDialog.findViewById(R.id.fltAllowOnLockscreen)).setFilterState(filterAllowOnLockscreen);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltScreenOn)).setFilterState(filterScreenOn);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltOrientation)).setFilterState(filterOrientation);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltResident)).setFilterState(filterResident);
@@ -239,6 +241,7 @@ public class XposedModActivity extends Activity {
 						filterLocale = FilterState.ALL;
 						filterFullscreen = FilterState.ALL;
 						filterNoTitle = FilterState.ALL;
+						filterAllowOnLockscreen = FilterState.ALL;
 						filterScreenOn = FilterState.ALL;
 						filterOrientation = FilterState.ALL;
 						filterResident = FilterState.ALL;
@@ -260,6 +263,7 @@ public class XposedModActivity extends Activity {
 						filterLocale = ((FilterItemComponent) filterDialog.findViewById(R.id.fltLocale)).getFilterState();
 						filterFullscreen = ((FilterItemComponent) filterDialog.findViewById(R.id.fltFullscreen)).getFilterState();
 						filterNoTitle = ((FilterItemComponent) filterDialog.findViewById(R.id.fltNoTitle)).getFilterState();
+						filterAllowOnLockscreen = ((FilterItemComponent) filterDialog.findViewById(R.id.fltAllowOnLockscreen)).getFilterState();
 						filterScreenOn = ((FilterItemComponent) filterDialog.findViewById(R.id.fltScreenOn)).getFilterState();
 						filterOrientation = ((FilterItemComponent) filterDialog.findViewById(R.id.fltOrientation)).getFilterState();
 						filterResident = ((FilterItemComponent) filterDialog.findViewById(R.id.fltResident)).getFilterState();
@@ -282,6 +286,7 @@ public class XposedModActivity extends Activity {
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltLocale)).setEnabled(enable);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltFullscreen)).setEnabled(enable);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltNoTitle)).setEnabled(enable);
+				((FilterItemComponent) filterDialog.findViewById(R.id.fltAllowOnLockscreen)).setEnabled(enable);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltScreenOn)).setEnabled(enable);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltOrientation)).setEnabled(enable);
 				((FilterItemComponent) filterDialog.findViewById(R.id.fltResident)).setEnabled(enable);
@@ -398,6 +403,8 @@ public class XposedModActivity extends Activity {
 			if (filteredOut(prefs.getBoolean(packageName + Common.PREF_FULLSCREEN, false), filterFullscreen))
 				return true;
 			if (filteredOut(prefs.getBoolean(packageName + Common.PREF_NO_TITLE, false), filterNoTitle))
+				return true;
+			if (filteredOut(prefs.getBoolean(packageName + Common.PREF_ALLOW_ON_LOCKSCREEN, false), filterAllowOnLockscreen))
 				return true;
 			if (filteredOut(prefs.getBoolean(packageName + Common.PREF_SCREEN_ON, false), filterScreenOn))
 				return true;

--- a/src/de/robv/android/xposed/mods/appsettings/hooks/Activities.java
+++ b/src/de/robv/android/xposed/mods/appsettings/hooks/Activities.java
@@ -37,6 +37,11 @@ public class Activities {
 
 					if (XposedMod.prefs.getBoolean(packageName + Common.PREF_NO_TITLE, false))
 						window.requestFeature(Window.FEATURE_NO_TITLE);
+					
+					if (XposedMod.prefs.getBoolean(packageName + Common.PREF_ALLOW_ON_LOCKSCREEN, false))
+		    				window.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
+		    				    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+		    				    WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON);
 
 					if (XposedMod.prefs.getBoolean(packageName + Common.PREF_SCREEN_ON, false))
 						window.addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);

--- a/src/de/robv/android/xposed/mods/appsettings/settings/ApplicationSettings.java
+++ b/src/de/robv/android/xposed/mods/appsettings/settings/ApplicationSettings.java
@@ -285,6 +285,16 @@ public class ApplicationSettings extends Activity {
 			}
 		});
 
+		// Update Allow On Lockscreen field
+		((CheckBox) findViewById(R.id.chkAllowOnLockscreen)).setChecked(prefs.getBoolean(pkgName + Common.PREF_ALLOW_ON_LOCKSCREEN, false));
+		// Track changes to the Allow On Lockscreen checkbox to know if the settings were changed
+		((CheckBox) findViewById(R.id.chkAllowOnLockscreen)).setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				dirty = true;
+			}
+		});
+
 		// Update Screen On field
 		((CheckBox) findViewById(R.id.chkScreenOn)).setChecked(prefs.getBoolean(pkgName + Common.PREF_SCREEN_ON, false));
 		// Track changes to the Screen On checkbox to know if the settings were changed
@@ -498,6 +508,11 @@ public class ApplicationSettings extends Activity {
 				} else {
 					prefsEditor.remove(pkgName + Common.PREF_NO_TITLE);
 				}
+				if (((CheckBox) findViewById(R.id.chkAllowOnLockscreen)).isChecked()) {
+					prefsEditor.putBoolean(pkgName + Common.PREF_ALLOW_ON_LOCKSCREEN, true);
+				} else {
+					prefsEditor.remove(pkgName + Common.PREF_ALLOW_ON_LOCKSCREEN);
+				}
 				if (((CheckBox) findViewById(R.id.chkScreenOn)).isChecked()) {
 					prefsEditor.putBoolean(pkgName + Common.PREF_SCREEN_ON, true);
 				} else {
@@ -541,6 +556,7 @@ public class ApplicationSettings extends Activity {
                 prefsEditor.remove(pkgName + Common.PREF_LOCALE);
                 prefsEditor.remove(pkgName + Common.PREF_FULLSCREEN);
                 prefsEditor.remove(pkgName + Common.PREF_NO_TITLE);
+                prefsEditor.remove(pkgName + Common.PREF_ALLOW_ON_LOCKSCREEN);
                 prefsEditor.remove(pkgName + Common.PREF_SCREEN_ON);
                 prefsEditor.remove(pkgName + Common.PREF_ORIENTATION);
                 prefsEditor.remove(pkgName + Common.PREF_RESIDENT);


### PR DESCRIPTION
I added a checkbox to allow applications to be shown on the lockscreen.
This can be useful if you want to make an app, e.g a music player, accessible without unlocking your phone.
