### PR TITLE
Fix DPI not loading on some devices if SystemUI setting is active

### DIFF
--- a/src/de/robv/android/xposed/mods/appsettings/XposedMod.java
+++ b/src/de/robv/android/xposed/mods/appsettings/XposedMod.java
@@ -305,9 +305,11 @@ public class XposedMod implements IXposedHookZygoteInit, IXposedHookLoadPackage 
 
 		for (String resName : SYSTEMUI_ADJUSTED_DIMENSIONS) {
 			int id = sysRes.getIdentifier(resName, "dimen", "android");
-			float original = sysRes.getDimension(id);
-			XResources.setSystemWideReplacement(id,
-					new DimensionReplacement(original * scaleFactor, TypedValue.COMPLEX_UNIT_PX));
+			if (id != 0) {
+				float original = sysRes.getDimension(id);
+				XResources.setSystemWideReplacement(id,
+						new DimensionReplacement(original * scaleFactor, TypedValue.COMPLEX_UNIT_PX));
+			}
 		}
 	}
 


### PR DESCRIPTION
If we find the dimensions with ID being zero, it will throw a
ResourceNotFoundException.

This causes the rest of the hooks after “adjustSystemDimensions” in
“initZygote” to not be called.
