### PR TITLE
Added support for Android 5.1

### DIFF
--- a/src/de/robv/android/xposed/mods/appsettings/hooks/Activities.java
+++ b/src/de/robv/android/xposed/mods/appsettings/hooks/Activities.java
@@ -40,7 +40,7 @@ public class Activities {
 	private static final String PROP_LEGACY_MENU = "AppSettings-LegacyMenu";
 	private static final String PROP_ORIENTATION = "AppSettings-Orientation";
 
-	private static int FLAG_NEEDS_MENU_KEY = getStaticIntField(WindowManager.LayoutParams.class, "FLAG_NEEDS_MENU_KEY");
+	private static int FLAG_NEEDS_MENU_KEY = Build.VERSION.SDK_INT < 22 ? getStaticIntField(WindowManager.LayoutParams.class, "FLAG_NEEDS_MENU_KEY") : 0;
 
 	public static void hookActivitySettings() {
 		try {

--- a/src/de/robv/android/xposed/mods/appsettings/settings/ApplicationSettings.java
+++ b/src/de/robv/android/xposed/mods/appsettings/settings/ApplicationSettings.java
@@ -341,7 +341,12 @@ public class ApplicationSettings extends Activity {
 		((CheckBox) findViewById(R.id.chkMute)).setChecked(prefs.getBoolean(pkgName + Common.PREF_MUTE, false));
 
 		// Update Legacy Menu field
-		((CheckBox) findViewById(R.id.chkLegacyMenu)).setChecked(prefs.getBoolean(pkgName + Common.PREF_LEGACY_MENU, false));
+		CheckBox showLegacyMenu = (CheckBox) findViewById(R.id.chkLegacyMenu);
+		if (Build.VERSION.SDK_INT >= 22) {
+			showLegacyMenu.setVisibility(View.GONE);
+		} else {
+			showLegacyMenu.setChecked(prefs.getBoolean(pkgName + Common.PREF_LEGACY_MENU, false));
+		}
 
 		// Setting for permissions revoking
 		allowRevoking = prefs.getBoolean(pkgName + Common.PREF_REVOKEPERMS, false);


### PR DESCRIPTION
There is no flag "FLAG_NEEDS_MENU_KEY" in Android 5.1 (and newer), so we should not look for it to prevent NoSuchFieldError, just set it to 0. Also hide option to show legacy menu, since it can't work on 5.1+.

I posted fixed version on XDA some time ago and reports say it works. Consider packing all Lollipop base fixes and this fix and release update to repo. (I read you don't have key for it, just resign it and inform users to uninstall and then install this new version)
